### PR TITLE
Fixed attributes for grasp_check.

### DIFF
--- a/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
@@ -272,7 +272,11 @@
 
       <!-- a formal implementation of grasp hack in gazebo with fixed joint -->
       <gripper name="${side}_grasp_hack">
-        <grasp_check attach_steps="20" detach_steps="40" min_contact_count="2" />
+        <grasp_check>
+          <attach_steps>20</attach_steps>
+          <detach_steps>40</detach_steps>
+          <min_contact_count>2</min_contact_count>
+        </grasp_check>
         <gripper_link>${side}_gripper_r_finger_tip_link</gripper_link>
         <gripper_link>${side}_gripper_l_finger_tip_link</gripper_link>
         <palm_link>${side}_gripper_palm_link</palm_link>


### PR DESCRIPTION
As of SDF 1.2, the properties of grasp_check should be defined as elements, not attributes ([reference](http://gazebosim.org/sdf/1.2.html#grasp_check)). This causes warnings and the attributes to be ignored in Gazebo 1.5, which uses SDF 1.3.
