### PR TITLE
Removed unused canonicalBody tag.

### DIFF
--- a/pr2_description/urdf/base_v0/base.gazebo.xacro
+++ b/pr2_description/urdf/base_v0/base.gazebo.xacro
@@ -48,7 +48,6 @@
         <xyzOffsets>0 0 0</xyzOffsets>
         <rpyOffsets>0 0 0</rpyOffsets>
       </plugin>
-      <canonicalBody>${name}_footprint</canonicalBody>
     </gazebo>
   </xacro:macro>
 


### PR DESCRIPTION
I believe the canonicalBody tag is no longer used by Gazebo. It produces the warning

```
Warning [parser_urdf.cc:481] do nothing with canonicalBody
```

(reference gazebo [model tutorial](http://gazebosim.org/wiki/Build_model), [sdf specification](http://gazebosim.org/sdf/1.0.html))
