### PR TITLE
Add and correct URDF plugin parameters

### DIFF
--- a/pr2_description/urdf/base_v0/base.gazebo.xacro
+++ b/pr2_description/urdf/base_v0/base.gazebo.xacro
@@ -31,6 +31,7 @@
           <alwaysOn>true</alwaysOn>
           <updateRate>100.0</updateRate>
           <bumperTopicName>${name}_bumper</bumperTopicName>
+          <frameName>world</frameName>
         </plugin>
       </sensor>
     </gazebo>

--- a/pr2_description/urdf/sensors/hokuyo_lx30_laser.gazebo.xacro
+++ b/pr2_description/urdf/sensors/hokuyo_lx30_laser.gazebo.xacro
@@ -30,6 +30,7 @@
           <updateRate>${update_rate}</updateRate>
           <topicName>${ros_topic}</topicName>
           <frameName>${name}_link</frameName>
+          <hokuyoMinIntensity>101</hokuyoMinIntensity>
         </plugin>
       </sensor>
     </gazebo>

--- a/pr2_description/urdf/sensors/kinect_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/kinect_camera.gazebo.xacro
@@ -25,7 +25,7 @@
         <imageTopicName>${name}/ir/image_raw</imageTopicName>
         <cameraInfoTopicName>${name}/ir/camera_info</cameraInfoTopicName>
         <depthImageTopicName>${name}/depth/image_raw</depthImageTopicName>
-        <depthImageInfoTopicName>${name}/depth/camera_info</depthImageInfoTopicName>
+        <depthImageCameraInfoTopicName>${name}/depth/camera_info</depthImageCameraInfoTopicName>
         <pointCloudTopicName>${name}/depth/points</pointCloudTopicName>
         <frameName>${name}_optical_frame</frameName>
         <pointCloudCutoff>0.5</pointCloudCutoff>
@@ -34,6 +34,11 @@
         <distortionK3>0.00000001</distortionK3>
         <distortionT1>0.00000001</distortionT1>
         <distortionT2>0.00000001</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
       </plugin>
     </sensor>
     <sensor type="depth" name="${name}_frame_sensor">
@@ -56,8 +61,10 @@
         <updateRate>20.0</updateRate>
         <cameraName>${name}</cameraName>
         <imageTopicName>${name}/rgb/image_raw</imageTopicName>
-        <pointCloudTopicName>${name}/rgb/points</pointCloudTopicName>
         <cameraInfoTopicName>${name}/rgb/camera_info</cameraInfoTopicName>
+        <depthImageTopicName>${name}/depth/image_raw</depthImageTopicName>
+        <depthImageCameraInfoTopicName>${name}/depth/camera_info</depthImageCameraInfoTopicName>
+        <pointCloudTopicName>${name}/rgb/points</pointCloudTopicName>
         <frameName>${name}_optical_frame</frameName>
         <pointCloudCutoff>0.5</pointCloudCutoff>
         <distortionK1>0.00000001</distortionK1>
@@ -65,6 +72,11 @@
         <distortionK3>0.00000001</distortionK3>
         <distortionT1>0.00000001</distortionT1>
         <distortionT2>0.00000001</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
       </plugin>
     </sensor>
   </gazebo>

--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
@@ -26,7 +26,7 @@
         <imageTopicName>/${camera_name}/depth/image_raw</imageTopicName>
         <cameraInfoTopicName>/${camera_name}/depth/camera_info</cameraInfoTopicName>
         <depthImageTopicName>/${camera_name}/depth/image_raw</depthImageTopicName>
-        <depthImageInfoTopicName>/${camera_name}/depth/camera_info</depthImageInfoTopicName>
+        <depthImageCameraInfoTopicName>/${camera_name}/depth/camera_info</depthImageCameraInfoTopicName>
         <pointCloudTopicName>/${camera_name}/depth/points</pointCloudTopicName>
         <frameName>${frame_name}</frameName>
         <pointCloudCutoff>0.5</pointCloudCutoff>
@@ -35,6 +35,11 @@
         <distortionK3>0.00000001</distortionK3>
         <distortionT1>0.00000001</distortionT1>
         <distortionT2>0.00000001</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
       </plugin>
     </sensor>
     <material value="Gazebo/Red" />
@@ -64,6 +69,8 @@
         <cameraName>${camera_name}_rgb</cameraName>
         <imageTopicName>/${camera_name}/rgb/image_raw</imageTopicName>
         <cameraInfoTopicName>/${camera_name}/rgb/camera_info</cameraInfoTopicName>
+        <depthImageTopicName>/${camera_name}/depth/image_raw</depthImageTopicName>
+        <depthImageCameraInfoTopicName>/${camera_name}/depth/camera_info</depthImageCameraInfoTopicName>
         <pointCloudTopicName>/${camera_name}/depth_registered/points</pointCloudTopicName>
         <frameName>${frame_name}</frameName>
         <pointCloudCutoff>0.5</pointCloudCutoff>
@@ -72,6 +79,11 @@
         <distortionK3>0.00000001</distortionK3>
         <distortionT1>0.00000001</distortionT1>
         <distortionT2>0.00000001</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
       </plugin>
     </sensor>
     <material value="Gazebo/Red" />
@@ -117,13 +129,22 @@
         <cameraName>${camera_name}_1mb</cameraName>
         <imageTopicName>image_raw</imageTopicName>
         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+        <depthImageTopicName>depth/image_raw</depthImageTopicName>
+        <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
         <pollServiceName>request_image</pollServiceName>
+        <pointCloudTopicName>points</pointCloudTopicName>
         <frameName>${frame_name}</frameName>
+        <pointCloudCutoff>0.4</pointCloudCutoff>
         <distortionK1>0.0</distortionK1>
         <distortionK2>0.0</distortionK2>
         <distortionK3>0.0</distortionK3>
         <distortionT1>0.0</distortionT1>
         <distortionT2>0.0</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
       </plugin>
     </sensor>
     <sensor type="depth" name="${link_name}_sim_pcd_sensor">
@@ -146,8 +167,22 @@
         <updateRate>1.0</updateRate>
         <cameraName>${camera_name}_1mb_sim_pcd</cameraName>
         <imageTopicName>image_raw</imageTopicName>
+        <depthImageTopicName>depth/image_raw</depthImageTopicName>
+        <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+        <pointCloudTopicName>points</pointCloudTopicName>
         <frameName>${frame_name}</frameName>
+        <pointCloudCutoff>0.4</pointCloudCutoff>
+        <distortionK1>0.00000001</distortionK1>
+        <distortionK2>0.00000001</distortionK2>
+        <distortionK3>0.00000001</distortionK3>
+        <distortionT1>0.00000001</distortionT1>
+        <distortionT2>0.00000001</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
       </plugin>
     </sensor>
     <material value="Gazebo/Red" />

--- a/pr2_description/urdf/torso_v0/torso.gazebo.xacro
+++ b/pr2_description/urdf/torso_v0/torso.gazebo.xacro
@@ -14,6 +14,7 @@
           <alwaysOn>true</alwaysOn>
           <updateRate>100.0</updateRate>
           <bumperTopicName>${name}_bumper</bumperTopicName>
+          <frameName>world</frameName>
         </plugin>
       </sensor>
     </gazebo>


### PR DESCRIPTION
A number of gazebo plugins are missing parameters, or have invalid parameters defined. Probably because the gazebo plugin API changed over the years and the PR2 URDF files weren't updated accordingly. I've added / changed / removed many of them as appropriate, which gets rid of a lot of info / warnings / errors when launching PR2 in Gazebo.
