### PR TITLE
Fixed more missing / incorrect URDF elements.

### DIFF
--- a/pr2_description/robots/pr2.urdf.xacro
+++ b/pr2_description/robots/pr2.urdf.xacro
@@ -141,14 +141,14 @@
   <!-- Forearm cam Orientation is from Function -->
   <xacro:wge100_camera_v0 name="l_forearm_cam" image_format="R8G8B8" camera_name="l_forearm_cam" image_topic_name="image_raw"
                           camera_info_topic_name="camera_info"
-                          parent="l_forearm_roll_link" hfov="90" focal_length="320"
+                          parent="l_forearm_roll_link" hfov="90" focal_length="320.000105"
                           frame_id="l_forearm_cam_optical_frame" hack_baseline="0"
                           image_width="640" image_height="480">
     <origin xyz=".135 0 .044" rpy="${-M_PI/2} ${-32.25*M_PI/180} 0" />
   </xacro:wge100_camera_v0>
   <xacro:wge100_camera_v0 name="r_forearm_cam" image_format="R8G8B8" camera_name="r_forearm_cam" image_topic_name="image_raw"
                           camera_info_topic_name="camera_info"
-                          parent="r_forearm_roll_link" hfov="90" focal_length="320"
+                          parent="r_forearm_roll_link" hfov="90" focal_length="320.000105"
                           frame_id="r_forearm_cam_optical_frame" hack_baseline="0"
                           image_width="640" image_height="480">
     <origin xyz=".135 0 .044" rpy="${M_PI/2} ${-32.25*M_PI/180} 0" />

--- a/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
@@ -119,7 +119,6 @@
         <updateRate>100.0</updateRate>
         <bodyName>${prefix}_l_finger_link</bodyName>
         <topicName>${prefix}_l_finger_force_ground_truth</topicName>
-        <frameName>${prefix}_l_finger_link</frameName>
       </plugin>
     </gazebo>
     <gazebo reference="${prefix}_r_finger_tip_joint">

--- a/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
@@ -46,10 +46,10 @@
 
     <!-- Wide camera is on robot right (hca1), narrow on left (hca2)? -->
     <!-- 15mm offset from center needs check with CAD -->
-    <xacro:stereo_camera_v0 parent="${name}_link" name="wide_stereo" focal_length="320" hfov="90" image_format="BAYER_BGGR8" image_width="640" image_height="480" >
+    <xacro:stereo_camera_v0 parent="${name}_link" name="wide_stereo" focal_length="320.000105" hfov="90" image_format="BAYER_BGGR8" image_width="640" image_height="480" >
       <origin xyz="0.045 ${0.045-0.015} 0.0501" rpy="0.0   0.0   0.0" />
     </xacro:stereo_camera_v0>
-    <xacro:stereo_camera_v0 parent="${name}_link" name="narrow_stereo" focal_length="772.55" hfov="45" image_format="L8" image_width="640" image_height="480" >
+    <xacro:stereo_camera_v0 parent="${name}_link" name="narrow_stereo" focal_length="772.548518" hfov="45" image_format="L8" image_width="640" image_height="480" >
       <origin xyz="0.045 ${0.045+0.015} 0.0501" rpy="0.0   0.0   0.0" />
     </xacro:stereo_camera_v0>
 

--- a/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro
+++ b/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro
@@ -12,6 +12,7 @@
         <gaussianNoise>${stdev*stdev}</gaussianNoise>
         <xyzOffset>0 0 0</xyzOffset> 
         <rpyOffset>0 -180.0 0</rpyOffset>
+        <serviceName>/default_imu</serviceName>
       </plugin>
     </gazebo>
   </xacro:macro>

--- a/pr2_description/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro
@@ -28,7 +28,7 @@
         <CxPrime>1224.5</CxPrime>
         <Cx>1224.5</Cx>
         <Cy>1025.5</Cy>
-        <focalLength>2955</focalLength>
+        <focalLength>2954.998083</focalLength>
         <distortionK1>0.0</distortionK1>
         <distortionK2>0.0</distortionK2>
         <distortionK3>0.0</distortionK3>

--- a/pr2_description/urdf/sensors/wge100_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/wge100_camera.gazebo.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="wge100_camera_gazebo_v0" params="name camera_name image_format image_topic_name camera_info_topic_name hfov focal_length frame_id hack_baseline image_width image_height">
     <gazebo reference="${name}_frame">
-      <sensor type="depth" name="${name}_sensor">
+      <sensor type="camera" name="${name}_sensor">
         <always_on>true</always_on>
         <update_rate>25.0</update_rate>
         <camera>
@@ -17,17 +17,13 @@
             <far>100</far>
           </clip>
         </camera>
-        <plugin name="${name}_controller" filename="libgazebo_ros_depth_camera.so">
+        <plugin name="${name}_controller" filename="libgazebo_ros_camera.so">
           <alwaysOn>true</alwaysOn>
           <updateRate>25.0</updateRate>
           <cameraName>${camera_name}</cameraName>
           <imageTopicName>${image_topic_name}</imageTopicName>
           <cameraInfoTopicName>${camera_info_topic_name}</cameraInfoTopicName>
-          <depthImageTopicName>${camera_name}/depth/image_raw</depthImageTopicName>
-          <depthImageCameraInfoTopicName>${camera_name}/depth/camera_info</depthImageCameraInfoTopicName>
-          <pointCloudTopicName>${camera_name}/depth/points</pointCloudTopicName>
           <frameName>${frame_id}</frameName>
-          <pointCloudCutoff>0.5</pointCloudCutoff>
           <hackBaseline>${hack_baseline}</hackBaseline>
           <CxPrime>${(image_width+1)/2}</CxPrime>
           <Cx>${(image_width+1)/2}</Cx>
@@ -40,7 +36,6 @@
           <distortionK3>0.0</distortionK3>
           <distortionT1>0.0</distortionT1>
           <distortionT2>0.0</distortionT2>
-          <hackBaseline>0</hackBaseline>
         </plugin>
       </sensor>
       <turnGravityOff>true</turnGravityOff>

--- a/pr2_description/urdf/sensors/wge100_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/wge100_camera.gazebo.xacro
@@ -23,7 +23,11 @@
           <cameraName>${camera_name}</cameraName>
           <imageTopicName>${image_topic_name}</imageTopicName>
           <cameraInfoTopicName>${camera_info_topic_name}</cameraInfoTopicName>
+          <depthImageTopicName>${camera_name}/depth/image_raw</depthImageTopicName>
+          <depthImageCameraInfoTopicName>${camera_name}/depth/camera_info</depthImageCameraInfoTopicName>
+          <pointCloudTopicName>${camera_name}/depth/points</pointCloudTopicName>
           <frameName>${frame_id}</frameName>
+          <pointCloudCutoff>0.5</pointCloudCutoff>
           <hackBaseline>${hack_baseline}</hackBaseline>
           <CxPrime>${(image_width+1)/2}</CxPrime>
           <Cx>${(image_width+1)/2}</Cx>
@@ -36,6 +40,7 @@
           <distortionK3>0.0</distortionK3>
           <distortionT1>0.0</distortionT1>
           <distortionT2>0.0</distortionT2>
+          <hackBaseline>0</hackBaseline>
         </plugin>
       </sensor>
       <turnGravityOff>true</turnGravityOff>


### PR DESCRIPTION
Some of these are just wrapping up elements that I missed in https://github.com/PR2/pr2_common/pull/219 . The incorrect focal_lengths are clearly just due to rounding errors in how Gazebo calculates focal lengths- not a big deal but they throw a bunch of warnings.
