### PR TITLE
Switched prosilica sensors from depth to camera because gazebo plugin has changed

### DIFF
--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
@@ -96,7 +96,7 @@
 
 <xacro:macro name="prosilica_cam_gazebo_v1" params="link_name frame_name camera_name ">
   <gazebo reference="${link_name}">
-    <sensor type="depth" name="${link_name}_sensor">
+    <sensor type="camera" name="${link_name}_sensor">
       <always_on>true</always_on>
       <update_rate>1.0</update_rate>
       <camera>

--- a/pr2_description/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro
@@ -3,7 +3,7 @@
   
 <xacro:macro name="prosilica_cam_gazebo_v0" params="camera_name frame_name">
   <gazebo reference="${frame_name}_frame">
-    <sensor type="depth" name="${frame_name}_sensor">
+    <sensor type="camera" name="${frame_name}_sensor">
       <always_on>true</always_on>
       <update_rate>20.0</update_rate>
       <camera>


### PR DESCRIPTION
Needed so that the PR2 launch with gazebo_ros_pkgs in Hydro

This is because the prosilica camera was recently changes to be a "camera" and not "depth" sensor type:
https://github.com/ros-simulation/gazebo_ros_pkgs/pull/82

@hsu @nkoenig @caguero
