### PR TITLE
removed developers warning in pr2_descriptions CMakeLists.txt

### DIFF
--- a/pr2_description/CMakeLists.txt
+++ b/pr2_description/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(it ${pr2_stl_files})
 
   IF ( ${basename} MATCHES "_convex" )
 
-    message("ignoring stale .._convex.stl file:",${basename})
+    message("ignoring stale .._convex.stl file:" ,${basename})
 
   ELSE ( ${basename} MATCHES "_convex" )
 


### PR DESCRIPTION
The added whitespace removed a developers warning.
