### PR TITLE
when using ROS Indigo and Gazebo 2.2.3, the name specified here must be ...

### DIFF
--- a/pr2_description/urdf/base_v0/base.gazebo.xacro
+++ b/pr2_description/urdf/base_v0/base.gazebo.xacro
@@ -25,7 +25,7 @@
         <always_on>true</always_on>
         <update_rate>100.0</update_rate>
         <contact>
-          <collision>${name}_link_geom</collision>
+          <collision>${name}_link_collision</collision>
         </contact>
         <plugin name="${name}_gazebo_ros_bumper_controller" filename="libgazebo_ros_bumper.so">
           <alwaysOn>true</alwaysOn>

--- a/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
@@ -62,7 +62,7 @@
       <sensor type="contact" name="${prefix}_l_finger_tip_contact_sensor">
         <update_rate>100.0</update_rate>
         <contact>
-          <collision>${prefix}_l_finger_tip_link_geom</collision>
+          <collision>${prefix}_l_finger_tip_link_collision</collision>
         </contact>
         <plugin name="${prefix}_l_finger_tip_gazebo_ros_bumper_controller" filename="libgazebo_ros_bumper.so">
           <alwaysOn>true</alwaysOn>
@@ -91,7 +91,7 @@
       <sensor type="contact" name="${prefix}_r_finger_tip_contact_sensor">
         <update_rate>100.0</update_rate>
         <contact>
-          <collision>${prefix}_r_finger_tip_link_geom</collision>
+          <collision>${prefix}_r_finger_tip_link_collision</collision>
         </contact>
         <plugin name="${prefix}_r_finger_tip_gazebo_ros_bumper_controller" filename="libgazebo_ros_bumper.so">
           <alwaysOn>true</alwaysOn>

--- a/pr2_description/urdf/torso_v0/torso.gazebo.xacro
+++ b/pr2_description/urdf/torso_v0/torso.gazebo.xacro
@@ -7,7 +7,7 @@
     <gazebo reference="${name}_link">
       <sensor type="contact" name="${name}_contact_sensor">
         <contact>
-          <collision>${name}_link_geom</collision>
+          <collision>${name}_link_collision</collision>
         </contact>
         <update_rate>100.0</update_rate>
         <plugin name="${name}_gazebo_ros_bumper_controller" filename="libgazebo_ros_bumper.so">


### PR DESCRIPTION
...<link_name>_collision

see #233
