### PR TITLE
[pr2_description] modify depth topic name of kinect_prosilica_camera

### DIFF
--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
@@ -23,8 +23,8 @@
         <alwaysOn>true</alwaysOn>
         <updateRate>1.0</updateRate>
         <cameraName>${camera_name}_ir</cameraName>
-        <imageTopicName>/${camera_name}/depth/image_raw</imageTopicName>
-        <cameraInfoTopicName>/${camera_name}/depth/camera_info</cameraInfoTopicName>
+        <imageTopicName>/${camera_name}/ir/image_raw</imageTopicName>
+        <cameraInfoTopicName>/${camera_name}/ir/camera_info</cameraInfoTopicName>
         <depthImageTopicName>/${camera_name}/depth/image_raw</depthImageTopicName>
         <depthImageCameraInfoTopicName>/${camera_name}/depth/camera_info</depthImageCameraInfoTopicName>
         <pointCloudTopicName>/${camera_name}/depth/points</pointCloudTopicName>


### PR DESCRIPTION
With this modification,  the below problem will be modified.
![a](https://cloud.githubusercontent.com/assets/3803922/10312205/44180458-6c85-11e5-9fe2-9f30c5616646.gif)

The confusing of topic was,
`encoding: 32FC1` and `encoding: mono8` so I change the `mono8` topic to use namespace `ir`
