### PR TITLE
Make names of joints and links for Kinect2 more intutive

### DIFF
--- a/pr2_description/CMakeLists.txt
+++ b/pr2_description/CMakeLists.txt
@@ -77,7 +77,7 @@ foreach(it ${pr2_stl_files})
       COMMAND ivcon
       ARGS ${basepath}/convex/${basename}_convex.obj ${basepath}/convex/${basename}_convex.iv
       DEPENDS ${basepath}/convex/${basename}_convex.obj)
-     
+
     set(pr2_gen_files ${pr2_gen_files} ${basepath}/iv/${basename}.iv ${basepath}/convex/${basename}_convex.iv)
 
 
@@ -97,6 +97,6 @@ if(CATKIN_ENABLE_TESTING)
 endif()
 
 foreach(dir meshes gazebo materials robots documents urdf)
-   install(DIRECTORY ${dir}/ 
+   install(DIRECTORY ${dir}/
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
 endforeach(dir)

--- a/pr2_description/CMakeLists.txt
+++ b/pr2_description/CMakeLists.txt
@@ -77,7 +77,7 @@ foreach(it ${pr2_stl_files})
       COMMAND ivcon
       ARGS ${basepath}/convex/${basename}_convex.obj ${basepath}/convex/${basename}_convex.iv
       DEPENDS ${basepath}/convex/${basename}_convex.obj)
-      
+     
     set(pr2_gen_files ${pr2_gen_files} ${basepath}/iv/${basename}.iv ${basepath}/convex/${basename}_convex.iv)
 
 

--- a/pr2_description/CMakeLists.txt
+++ b/pr2_description/CMakeLists.txt
@@ -77,7 +77,7 @@ foreach(it ${pr2_stl_files})
       COMMAND ivcon
       ARGS ${basepath}/convex/${basename}_convex.obj ${basepath}/convex/${basename}_convex.iv
       DEPENDS ${basepath}/convex/${basename}_convex.obj)
-
+      
     set(pr2_gen_files ${pr2_gen_files} ${basepath}/iv/${basename}.iv ${basepath}/convex/${basename}_convex.iv)
 
 
@@ -97,6 +97,6 @@ if(CATKIN_ENABLE_TESTING)
 endif()
 
 foreach(dir meshes gazebo materials robots documents urdf)
-   install(DIRECTORY ${dir}/
+   install(DIRECTORY ${dir}/ 
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
 endforeach(dir)

--- a/pr2_description/urdf/sensors/kinect2.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect2.urdf.xacro
@@ -6,12 +6,12 @@
 
   <!-- Kinect2 and mount assembly -->
   <xacro:macro name="kinect2_v0" params="name parent *origin">
-    <joint name="${name}_joint" type="fixed">
+    <joint name="${name}_kinect2_joint" type="fixed">
       <insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="${name}_link"/>
+      <child link="${name}_kinect2_link"/>
     </joint>
-    <link name="${name}_link">
+    <link name="${name}_kinect2_link">
       <inertial>
         <mass value="0.1"/>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -39,7 +39,7 @@
     <!-- kinect2 ir sensor physical attachment -->
     <joint name="${name}_kinect2_ir_joint" type="fixed">
       <origin xyz="-0.032267 -0.0475 0.155" rpy="0 0 0"/>
-      <parent link="${name}_link"/>
+      <parent link="${name}_kinect2_link"/>
       <child link="${name}_kinect2_ir_link"/>
     </joint>
     <link name="${name}_kinect2_ir_link">


### PR DESCRIPTION
Used to be "head_mount_link" and "head_mount_joint"
Changed to be "head_mount_kinect2_link" and "head_mount_kinect2_joint"
