### PR TITLE
Adding pr2-head to sim.machine at localhost

### DIFF
--- a/pr2_machine/sim.machine
+++ b/pr2_machine/sim.machine
@@ -3,4 +3,5 @@
        on env-loader attribute -->
   <machine name="c1" address="localhost" default="true" />   
   <machine name="c2" address="localhost" />   
+  <machine name="pr2-head" address="localhost" />
 </launch>


### PR DESCRIPTION
The pr2-head machine should also be defined in sim.machine (mapped to address=localhost) for cases where the PR2 is run in simulation on 1 machine, similar to c1 and c2 definitions.
