### PR TITLE
Prepend xacro tags with xacro xml namespace

### DIFF
--- a/pr2_description/urdf/base_v0/base.urdf.xacro
+++ b/pr2_description/urdf/base_v0/base.urdf.xacro
@@ -13,35 +13,35 @@
   <!-- all link geometry sizes are obtained from Function provided CAD model unless stated otherwise -->
   <!-- all simplified collision geometry are hand approximated from CAD model, sometimes from respective bounding boxes -->
 
-  <property name="M_PI" value="3.1415926535897931" />
+  <xacro:property name="M_PI" value="3.1415926535897931" />
 
-  <property name="caster_offset_x" value="0.2246" />
-  <property name="caster_offset_y" value="0.2246" />
-  <property name="caster_offset_z" value="0.0282" />
+  <xacro:property name="caster_offset_x" value="0.2246" />
+  <xacro:property name="caster_offset_y" value="0.2246" />
+  <xacro:property name="caster_offset_z" value="0.0282" />
 
-  <property name="caster_wheel_offset_y" value="0.049" />
-  <property name="wheel_length" value="0.034" />
-  <property name="wheel_radius" value="0.074792" />   <!-- This is the 'effective' wheel radius. Wheel radius for uncompressed wheel is 0.079.  mp 20080801 -->
+  <xacro:property name="caster_wheel_offset_y" value="0.049" />
+  <xacro:property name="wheel_length" value="0.034" />
+  <xacro:property name="wheel_radius" value="0.074792" />   <!-- This is the 'effective' wheel radius. Wheel radius for uncompressed wheel is 0.079.  mp 20080801 -->
 
-  <property name="base_cg_x" value="-0.061" />
-  <property name="base_cg_y" value="0.0" />
-  <property name="base_cg_z" value="${0.5*0.293}" />
-  <property name="base_mass" value="116.0" />
+  <xacro:property name="base_cg_x" value="-0.061" />
+  <xacro:property name="base_cg_y" value="0.0" />
+  <xacro:property name="base_cg_z" value="${0.5*0.293}" />
+  <xacro:property name="base_mass" value="116.0" />
 
   <!-- simplified box collision geometry for base -->
-  <property name="base_size_x" value="0.65" />
-  <property name="base_size_y" value="0.65" />
-  <property name="base_size_z" value="0.23" />
-  <property name="base_collision_size_z" value="0.04" />
+  <xacro:property name="base_size_x" value="0.65" />
+  <xacro:property name="base_size_y" value="0.65" />
+  <xacro:property name="base_size_z" value="0.23" />
+  <xacro:property name="base_collision_size_z" value="0.04" />
 
   <!-- simplified box collision geometry for hokuyo laser -->
-  <property name="base_laser_x" value="0.275" />
-  <property name="base_laser_y" value="0.0" />
-  <property name="base_laser_z" value="0.252" />
-  <property name="base_laser_size_x" value="0.06" />
-  <property name="base_laser_size_y" value="0.06" />
-  <property name="base_laser_size_z" value="0.03" />
-  <property name="base_laser_collision_offset_z" value="0.023" />
+  <xacro:property name="base_laser_x" value="0.275" />
+  <xacro:property name="base_laser_y" value="0.0" />
+  <xacro:property name="base_laser_z" value="0.252" />
+  <xacro:property name="base_laser_size_x" value="0.06" />
+  <xacro:property name="base_laser_size_y" value="0.06" />
+  <xacro:property name="base_laser_size_z" value="0.03" />
+  <xacro:property name="base_laser_collision_offset_z" value="0.023" />
 
   <!--                                                      -->
   <!--           wheel                                      -->
@@ -94,7 +94,7 @@
       <safety_controller  k_velocity="10" />
       <calibration rising="${ref_position}" />
       <dynamics damping="1.0" friction="0.0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${suffix}_rotation_link" />
     </joint>
@@ -132,7 +132,7 @@
 
     <xacro:pr2_caster_hub_v0 parent="${parent}" suffix="${suffix}_caster"
                              ref_position="${ref_position}" >
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
     </xacro:pr2_caster_hub_v0>
 
     <!-- wheel macros -->

--- a/pr2_description/urdf/common.xacro
+++ b/pr2_description/urdf/common.xacro
@@ -1,71 +1,74 @@
 <?xml version="1.0"?>
-<robot>
+<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <property name="M_PI" value="3.1415926535897931" />
-  <property name="VELOCITY_LIMIT_SCALE" value="0.6" />
+  <xacro:property name="M_PI" value="3.1415926535897931" />
+  <xacro:property name="VELOCITY_LIMIT_SCALE" value="0.6" />
 
   <!-- Gear Ratio Corrections: Divide transmission reductions by these factors (Nominally 1)-->
-  <property name="cal_r_shoulder_pan_gearing"   value="1.0" />
-  <property name="cal_r_shoulder_lift_gearing"  value="1.0" />
-  <property name="cal_r_upper_arm_roll_gearing" value="1.0" />
+  <xacro:property name="cal_r_shoulder_pan_gearing"   value="1.0" />
+  <xacro:property name="cal_r_shoulder_lift_gearing"  value="1.0" />
+  <xacro:property name="cal_r_upper_arm_roll_gearing" value="1.0" />
 
   <!-- ********** Right Arm ********** -->
   <!-- Flag offsets: Add to the optical flag locations (Nominally 0) -->
-  <property name="cal_r_shoulder_pan_flag"   value="0.0" />
-  <property name="cal_r_shoulder_lift_flag"  value="0.0" />
-  <property name="cal_r_upper_arm_roll_flag" value="0.0" />
-  <property name="cal_r_elbow_flex_flag"     value="0.0" />
-  <property name="cal_r_forearm_roll_flag"   value="0.0" />
-  <property name="cal_r_wrist_flex_flag"     value="0.0" />
-  <property name="cal_r_wrist_roll_flag"     value="0.0" />
-  
+  <xacro:property name="cal_r_shoulder_pan_flag"   value="0.0" />
+  <xacro:property name="cal_r_shoulder_lift_flag"  value="0.0" />
+  <xacro:property name="cal_r_upper_arm_roll_flag" value="0.0" />
+  <xacro:property name="cal_r_elbow_flex_flag"     value="0.0" />
+  <xacro:property name="cal_r_forearm_roll_flag"   value="0.0" />
+  <xacro:property name="cal_r_wrist_flex_flag"     value="0.0" />
+  <xacro:property name="cal_r_wrist_roll_flag"     value="0.0" />
+
   <!-- ********** Head ********** -->
   <!-- Head Location: Add to the transform from torso to head_pan_link (Nominally 0) -->
-  <property name="cal_head_x" value="0.0" />
-  <property name="cal_head_y" value="0.0" />
-  <property name="cal_head_z" value="0.0" />
-  <property name="cal_head_roll" value="0.0" />
-  <property name="cal_head_pitch" value="0.0" />
-  <property name="cal_head_yaw" value="0.0" />
+  <xacro:property name="cal_head_x" value="0.0" />
+  <xacro:property name="cal_head_y" value="0.0" />
+  <xacro:property name="cal_head_z" value="0.0" />
+  <xacro:property name="cal_head_roll" value="0.0" />
+  <xacro:property name="cal_head_pitch" value="0.0" />
+  <xacro:property name="cal_head_yaw" value="0.0" />
 
-  <!-- Flag Offsets -->  
-  <property name="cal_head_pan_flag"  value="0.0" />
-  <property name="cal_head_tilt_flag" value="0.0" />
+  <!-- Flag Offsets -->
+  <xacro:property name="cal_head_pan_flag"  value="0.0" />
+  <xacro:property name="cal_head_tilt_flag" value="0.0" />
 
-  <property name="cal_head_pan_flag" value="0.0"/>
-  <property name="cal_head_tilt_flag" value="0.0"/>
-  
+  <xacro:property name="cal_head_pan_flag" value="0.0"/>
+  <xacro:property name="cal_head_tilt_flag" value="0.0"/>
+
   <!-- Casters -->
-  <property name="cal_caster_fl" value="0.0" />
-  <property name="cal_caster_fr" value="0.0" />
-  <property name="cal_caster_bl" value="0.0" />
-  <property name="cal_caster_br" value="0.0" />
+  <xacro:property name="cal_caster_fl" value="0.0" />
+  <xacro:property name="cal_caster_fr" value="0.0" />
+  <xacro:property name="cal_caster_bl" value="0.0" />
+  <xacro:property name="cal_caster_br" value="0.0" />
 
   <!-- Stereo Camera Location (Nominally 0) -->
-  <property name="cal_stereo_x" value="0.0" />
-  <property name="cal_stereo_y" value="0.0" />
-  <property name="cal_stereo_z" value="0.0" />
-  <property name="cal_stereo_roll" value="0.0" />
-  <property name="cal_stereo_pitch" value="0.0" />
-  <property name="cal_stereo_yaw" value="0.0" />
+  <xacro:property name="cal_stereo_x" value="0.0" />
+  <xacro:property name="cal_stereo_y" value="0.0" />
+  <xacro:property name="cal_stereo_z" value="0.0" />
+  <xacro:property name="cal_stereo_roll" value="0.0" />
+  <xacro:property name="cal_stereo_pitch" value="0.0" />
+  <xacro:property name="cal_stereo_yaw" value="0.0" />
 
   <!-- Kinect Camera Location (Nominally 0) -->
-  <property name="cal_kinect_x" value="0.0" />
-  <property name="cal_kinect_y" value="0.0" />
-  <property name="cal_kinect_z" value="0.0" />
-  <property name="cal_kinect_roll" value="0.0" />
-  <property name="cal_kinect_pitch" value="0.0" />
-  <property name="cal_kinect_yaw" value="0.0" />
+  <xacro:property name="cal_kinect_x" value="0.0" />
+  <xacro:property name="cal_kinect_y" value="0.0" />
+  <xacro:property name="cal_kinect_z" value="0.0" />
+  <xacro:property name="cal_kinect_roll" value="0.0" />
+  <xacro:property name="cal_kinect_pitch" value="0.0" />
+  <xacro:property name="cal_kinect_yaw" value="0.0" />
 
   <!-- HighDef Camera Location (Nominally 0) -->
-  <property name="cal_high_def_x" value="0.0" />
-  <property name="cal_high_def_y" value="0.0" />
-  <property name="cal_high_def_z" value="0.0" />
-  <property name="cal_high_def_roll" value="0.0" />
-  <property name="cal_high_def_pitch" value="0.0" />
-  <property name="cal_high_def_yaw" value="0.0" />
+  <xacro:property name="cal_high_def_x" value="0.0" />
+  <xacro:property name="cal_high_def_y" value="0.0" />
+  <xacro:property name="cal_high_def_z" value="0.0" />
+  <xacro:property name="cal_high_def_roll" value="0.0" />
+  <xacro:property name="cal_high_def_pitch" value="0.0" />
+  <xacro:property name="cal_high_def_yaw" value="0.0" />
 
   <!-- Throwing in left arm constants to appease the xacro parser -->
-  <property name="cal_l_shoulder_pan_flag" value="0.000000" />
-  <property name="cal_l_wrist_roll_flag" value="0.0" />
+  <xacro:property name="cal_l_shoulder_pan_flag" value="0.000000" />
+  <xacro:property name="cal_l_wrist_roll_flag" value="0.0" />
 </robot>

--- a/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
@@ -17,7 +17,7 @@
   <xacro:macro name="pr2_forearm_v0" params="side parent reflect *origin">
 
     <joint name="${side}_forearm_joint" type="fixed">
-      <insert_block name="origin" /> <!-- transform from parent link to this joint frame -->
+      <xacro:insert_block name="origin" /> <!-- transform from parent link to this joint frame -->
       <parent link="${parent}"/>
       <child link="${side}_forearm_link"/>
     </joint>

--- a/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
@@ -1,23 +1,23 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <property name="finger_stop_kd"             value="1.0" />
-  <property name="finger_stop_kp"             value="10000000.0" />
-  <property name="finger_fudge_factor"        value="1.0" />
+  <xacro:property name="finger_stop_kd"             value="1.0" />
+  <xacro:property name="finger_stop_kp"             value="10000000.0" />
+  <xacro:property name="finger_fudge_factor"        value="1.0" />
 
-  <property name="finger_kp"                  value="0.0" />
-  <property name="finger_kd"                  value="0.0" />
-  <property name="finger_fm"                  value="0.0" />
+  <xacro:property name="finger_kp"                  value="0.0" />
+  <xacro:property name="finger_kd"                  value="0.0" />
+  <xacro:property name="finger_fm"                  value="0.0" />
 
-  <property name="finger_tip_kp"              value="0.0" />
-  <property name="finger_tip_kd"              value="0.0" />
-  <property name="finger_tip_fm"              value="0.0" />
+  <xacro:property name="finger_tip_kp"              value="0.0" />
+  <xacro:property name="finger_tip_kd"              value="0.0" />
+  <xacro:property name="finger_tip_fm"              value="0.0" />
 
-  <property name="finger_tip_mu"              value="500.0" />
-  <property name="finger_mu"                  value="500.0" />
+  <xacro:property name="finger_tip_mu"              value="500.0" />
+  <xacro:property name="finger_mu"                  value="500.0" />
 
-  <property name="parallel_link_x_offset"     value="-0.018" />
-  <property name="parallel_link_y_offset"     value="0.021" />
+  <xacro:property name="parallel_link_x_offset"     value="-0.018" />
+  <xacro:property name="parallel_link_y_offset"     value="0.021" />
 
   <xacro:macro name="pr2_finger_gazebo_v0" params="prefix reflect">
 

--- a/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
@@ -8,19 +8,19 @@
   <xacro:include filename="$(find pr2_description)/urdf/gripper_v0/gripper.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/gripper_v0/gripper.transmission.xacro" />
 
-  <property name="M_PI" value="3.1415926535897931" />
+  <xacro:property name="M_PI" value="3.1415926535897931" />
 
-  <property name="gripper_upper_angle" value="0.548" />
-  <property name="gripper_lower_angle" value="0.00" />
+  <xacro:property name="gripper_upper_angle" value="0.548" />
+  <xacro:property name="gripper_lower_angle" value="0.00" />
 
-  <property name="finger_damping"             value="0.02" />
-  <property name="gripper_damping"            value="10.0" />
-  <property name="finger_tip_damping"         value="0.001" />
+  <xacro:property name="finger_damping"             value="0.02" />
+  <xacro:property name="gripper_damping"            value="10.0" />
+  <xacro:property name="finger_tip_damping"         value="0.001" />
 
-  <property name="finger_joint_effort_limit"  value="1000.0" />
+  <xacro:property name="finger_joint_effort_limit"  value="1000.0" />
 
-  <property name="finger_to_finger_tip_x"     value="0.09137" />
-  <property name="palm_to_finger_x"           value="0.07691" />
+  <xacro:property name="finger_to_finger_tip_x"     value="0.09137" />
+  <xacro:property name="palm_to_finger_x"           value="0.07691" />
 
   <xacro:macro name="pr2_finger_limits_v0">
     <!-- limits on passive finger and finger top joints without
@@ -197,7 +197,7 @@
   <xacro:macro name="pr2_gripper_v0" params="side reflect parent *origin gear_ratio screw_reduction theta0 phi0 t0 L0 h a b r">
 
     <joint name="${side}_gripper_palm_joint" type="fixed">
-      <insert_block name="origin"/>
+      <xacro:insert_block name="origin"/>
       <parent link="${parent}"/>
       <child link="${side}_gripper_palm_link"/>
     </joint>

--- a/pr2_description/urdf/head_v0/head.urdf.xacro
+++ b/pr2_description/urdf/head_v0/head.urdf.xacro
@@ -8,7 +8,7 @@
   <xacro:include filename="$(find pr2_description)/urdf/head_v0/head.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/head_v0/head.transmission.xacro" />
 
-  <property name="M_PI" value="3.1415926535897931" />
+  <xacro:property name="M_PI" value="3.1415926535897931" />
 
   <xacro:macro name="pr2_head_pan_v0" params="name parent *origin">
     <joint name="${name}_joint" type="revolute">
@@ -17,7 +17,7 @@
       <safety_controller k_velocity="1.5" soft_lower_limit="${-3.007+0.15}" soft_upper_limit="${3.007-0.15}" k_position="100" />
       <calibration rising="0.0" />
       <dynamics damping="0.5" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>
@@ -60,7 +60,7 @@
       <safety_controller k_velocity="3.0" soft_lower_limit="${-0.4712 + 0.1}" soft_upper_limit="${1.39626 - 0.1}" k_position="100" />
       <calibration falling="${0.0+cal_head_tilt_flag}" />
       <dynamics damping="10.0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>
@@ -98,7 +98,7 @@
 
   <xacro:macro name="pr2_head_v0" params="name parent *origin">
     <xacro:pr2_head_pan_v0 name="${name}_pan" parent="${parent}">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
     </xacro:pr2_head_pan_v0>
 
     <xacro:pr2_head_tilt_v0 name="${name}_tilt" parent="${name}_pan_link">

--- a/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
@@ -8,18 +8,18 @@
   <xacro:include filename="$(find pr2_description)/urdf/sensors/double_stereo_camera.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/sensors/stereo_camera.urdf.xacro" />
 
-  <property name="stereo_size_x" value="0.02" />
-  <property name="stereo_size_y" value="0.12" />
-  <property name="stereo_size_z" value="0.05" />
-  <property name="stereo_center_box_center_offset_x" value="-0.01" />
-  <property name="stereo_center_box_center_offset_z" value="0.025" />
+  <xacro:property name="stereo_size_x" value="0.02" />
+  <xacro:property name="stereo_size_y" value="0.12" />
+  <xacro:property name="stereo_size_z" value="0.05" />
+  <xacro:property name="stereo_center_box_center_offset_x" value="-0.01" />
+  <xacro:property name="stereo_center_box_center_offset_z" value="0.025" />
 
   <!-- Made by Kevin for double stereo camera for PR-2 Beta. -->
   <!-- Needs calibration verification, and CAD check. -->
   <xacro:macro name="double_stereo_camera_v0" params="name parent *origin">
     <!-- Define link to stereo cameras, set origin relative to that -->
     <joint name="${name}_frame_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
@@ -5,7 +5,7 @@
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <property name="M_PI" value="3.1415926535897931" />
+  <xacro:property name="M_PI" value="3.1415926535897931" />
 
 
   <!-- Made by Kevin for A2 sensor package -->

--- a/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
@@ -18,7 +18,7 @@
   <!-- When mounted properly, should have same origin as head plate frame -->
   <xacro:macro name="pr2_head_sensor_package_v0" params="name hd_frame_name hd_camera_name stereo_name parent *origin">
     <joint name="${name}_frame_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
+++ b/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
@@ -10,7 +10,7 @@
   <xacro:macro name="hokuyo_lx30_laser_v0" params="name parent *origin ros_topic update_rate min_angle max_angle">
     <joint name="${name}_joint" type="fixed">
       <axis xyz="0 1 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}_link"/>
       <child link="${name}_link"/>
     </joint>

--- a/pr2_description/urdf/sensors/kinect2.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect2.urdf.xacro
@@ -2,12 +2,12 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect2.gazebo.xacro" />
 
-  <property name="ir_depth_rgb_offset_y" value="0.01"/> <!-- FIXME: what is this offset? -->
+  <xacro:property name="ir_depth_rgb_offset_y" value="0.01"/> <!-- FIXME: what is this offset? -->
 
   <!-- Kinect2 and mount assembly -->
   <xacro:macro name="kinect2_v0" params="name parent *origin">
     <joint name="${name}_kinect2_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_kinect2_link"/>
     </joint>

--- a/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
@@ -8,7 +8,7 @@
 
   <xacro:macro name="kinect_camera_v0" params="name parent *origin">
     <joint name="${name}_frame_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_frame"/>
     </joint>

--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
@@ -6,14 +6,14 @@
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_prosilica_camera.gazebo.xacro" />
 
-  <property name="ir_depth_rgb_offset_y" value="0.01"/> <!-- FIXME: what is this offset? -->
+  <xacro:property name="ir_depth_rgb_offset_y" value="0.01"/> <!-- FIXME: what is this offset? -->
 
   <!-- kinect and prosilica combo -->
   <xacro:macro name="kinect_prosilica_camera_swept_back_v0" params="name parent *origin">
     <!-- stl contains structure + kinect + prosilica combo -->
     <joint name="${name}_joint" type="fixed">
       <!-- <limit lower="0.1" upper="0.1" effort="10000" velocity="100.0"/> -->
-      <!-- <insert_block name="origin" /> -->
+      <!-- <xacro:insert_block name="origin" /> -->
       <origin xyz="-0.138 0 0.091" rpy="0 0 0"/>
       <parent link="${parent}"/>
       <child link="${name}_link"/>

--- a/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.urdf.xacro
+++ b/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.urdf.xacro
@@ -7,7 +7,7 @@
   <xacro:macro name="microstrain_3dmgx2_imu_v0" params="name parent *origin imu_topic update_rate stdev">
     <joint name="${name}_joint" type="fixed">
       <axis xyz="0 1 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}_link"/>
       <child link="${name}_link"/>
     </joint>

--- a/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
+++ b/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
@@ -8,7 +8,7 @@
 
   <xacro:macro name="projector_wg6802418_v0" params="name parent *origin">
     <joint name="${name}_frame_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_frame"/>
     </joint>

--- a/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
@@ -8,7 +8,7 @@
 
   <xacro:macro name="prosilica_cam_v0" params="frame_name parent *origin camera_name">
     <joint name="${frame_name}_frame_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${frame_name}_frame"/>
     </joint>

--- a/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
@@ -10,18 +10,18 @@
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/stereo_camera.gazebo.xacro" />
 
-  <property name="stereo_dx" value="0.00" />
-  <property name="stereo_dy" value="-0.09" /> <!-- +y to the left -->
-  <property name="stereo_dz" value="0.00" />
-  <property name="stereo_rx" value="0.00" />
-  <property name="stereo_ry" value="0.00" />
-  <property name="stereo_rz" value="0.00" />
+  <xacro:property name="stereo_dx" value="0.00" />
+  <xacro:property name="stereo_dy" value="-0.09" /> <!-- +y to the left -->
+  <xacro:property name="stereo_dz" value="0.00" />
+  <xacro:property name="stereo_rx" value="0.00" />
+  <xacro:property name="stereo_ry" value="0.00" />
+  <xacro:property name="stereo_rz" value="0.00" />
 
   <!-- this macro is used for creating wide and narrow double stereo camera links -->
   <xacro:macro name="stereo_camera_v0" params="name parent focal_length hfov image_format image_width image_height *origin">
 
     <joint name="${name}_frame_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
@@ -12,7 +12,7 @@
   <xacro:macro name="wge100_camera_v0" params="name camera_name image_format image_topic_name camera_info_topic_name parent hfov focal_length frame_id hack_baseline image_width image_height *origin">
 
     <joint name="${name}_frame_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_frame"/>
     </joint>

--- a/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
@@ -12,8 +12,8 @@
   <xacro:include filename="$(find pr2_description)/urdf/shoulder_v0/shoulder.transmission.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/common.xacro" />
 
-  <property name="shoulder_lift_length" value="0.10" />  <!--TODO Define and give source-->
-  <property name="shoulder_lift_radius" value="0.12" />  <!--TODO Define and give source-->
+  <xacro:property name="shoulder_lift_length" value="0.10" />  <!--TODO Define and give source-->
+  <xacro:property name="shoulder_lift_radius" value="0.12" />  <!--TODO Define and give source-->
 
  <!-- ============================   Shoulder   ============================ -->
 
@@ -22,7 +22,7 @@
     <!-- Shoulder pan -->
     <joint name="${side}_shoulder_pan_joint" type="revolute">
       <axis xyz="0 0 1" />
-      <insert_block name="origin" /> <!-- transform from parent link to this joint frame -->
+      <xacro:insert_block name="origin" /> <!-- transform from parent link to this joint frame -->
       <parent link="${parent}"/>
       <child link="${side}_shoulder_pan_link"/>
       <limit lower="${reflect*M_PI/4-1.5}"  upper="${reflect*M_PI/4+1.5}"
@@ -122,7 +122,7 @@
   <xacro:macro name="pr2_upper_arm_roll_v0" params="side parent reflect *origin">
     <joint name="${side}_upper_arm_roll_joint" type="revolute">
       <axis xyz="1 0 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${side}_upper_arm_roll_link"/>
       <limit lower="${reflect*1.55-2.35}" upper="${reflect*1.55+2.35}" effort="30" velocity="${VELOCITY_LIMIT_SCALE*5.45}" /> <!-- alpha tested velocity and effort limits -->

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
@@ -17,7 +17,7 @@
       <safety_controller k_position="100" k_velocity="0.05" soft_lower_limit="${-0.7854+0.05}" soft_upper_limit="${1.48353-0.05}" />
       <calibration falling="${laser_calib_ref}" />
       <dynamics damping="0.008" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_mount_link"/>
     </joint>

--- a/pr2_description/urdf/torso_v0/torso.urdf.xacro
+++ b/pr2_description/urdf/torso_v0/torso.urdf.xacro
@@ -15,7 +15,7 @@
       <safety_controller  k_velocity="2000000" soft_lower_limit="${0.0+0.0115}" soft_upper_limit="${0.33-0.005}" k_position="100" />
       <calibration falling="0.00475" />
       <dynamics damping="20000.0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
@@ -13,25 +13,25 @@
   <xacro:include filename="$(find pr2_description)/urdf/common.xacro" />
 
   <!-- Inertial properties differ slightly for left vs right arm -->
-  <property name="uar_xyz1" value= "0.21398" />
-  <property name="uar_xyz2" value="-0.01621" />
-  <property name="uar_xyz3" value="-0.00020" />
-  <property name="uar_ixx"  value= "0.01537748957" />
-  <property name="uar_ixy"  value= "0.00375711247" />
-  <property name="uar_ixz"  value="-0.00070852914" />
-  <property name="uar_iyy"  value= "0.07473670440" />
-  <property name="uar_iyz"  value="-0.00017936450" />
-  <property name="uar_izz"  value= "0.07608763307" />
+  <xacro:property name="uar_xyz1" value= "0.21398" />
+  <xacro:property name="uar_xyz2" value="-0.01621" />
+  <xacro:property name="uar_xyz3" value="-0.00020" />
+  <xacro:property name="uar_ixx"  value= "0.01537748957" />
+  <xacro:property name="uar_ixy"  value= "0.00375711247" />
+  <xacro:property name="uar_ixz"  value="-0.00070852914" />
+  <xacro:property name="uar_iyy"  value= "0.07473670440" />
+  <xacro:property name="uar_iyz"  value="-0.00017936450" />
+  <xacro:property name="uar_izz"  value= "0.07608763307" />
 
-  <property name="ual_xyz1" value= "0.21405" />
-  <property name="ual_xyz2" value= "0.01658" />
-  <property name="ual_xyz3" value="-0.00057" />
-  <property name="ual_ixx"  value= "0.01530603856" />
-  <property name="ual_ixy"  value="-0.00339324862" />
-  <property name="ual_ixz"  value= "0.00060765455" />
-  <property name="ual_iyy"  value= "0.07473694455" />
-  <property name="ual_iyz"  value="-0.00019953729" />
-  <property name="ual_izz"  value= "0.07601594191" />
+  <xacro:property name="ual_xyz1" value= "0.21405" />
+  <xacro:property name="ual_xyz2" value= "0.01658" />
+  <xacro:property name="ual_xyz3" value="-0.00057" />
+  <xacro:property name="ual_ixx"  value= "0.01530603856" />
+  <xacro:property name="ual_ixy"  value="-0.00339324862" />
+  <xacro:property name="ual_ixz"  value= "0.00060765455" />
+  <xacro:property name="ual_iyy"  value= "0.07473694455" />
+  <xacro:property name="ual_iyz"  value="-0.00019953729" />
+  <xacro:property name="ual_izz"  value= "0.07601594191" />
 
 
   <!-- ============================   Upper Arm   ============================ -->


### PR DESCRIPTION
When using in Kinetic xacro outputs the following warning:

```
deprecated: xacro tags should be prepended with 'xacro' xml namespace.
Use the following script to fix incorrect usage:
        find . -iname "*.xacro" | xargs sed -i 's#<\([/]\?\)\(if\|unless\|include\|arg\|property\|macro\|insert_block\)#<\1xacro:\2#g'
```

so i did that.