### PR TITLE
Fix inconsistent namespace redefinitions for xmlns:xacro

### DIFF
--- a/pr2_description/robots/pr2.urdf.xacro
+++ b/pr2_description/robots/pr2.urdf.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-       xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
+       xmlns:xacro="http://ros.org/wiki/xacro"
        name="pr2" >
 
   <!-- The following included files set up definitions of parts of the robot body -->

--- a/pr2_description/robots/pr2_no_arms.urdf.xacro
+++ b/pr2_description/robots/pr2_no_arms.urdf.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-       xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
+       xmlns:xacro="http://ros.org/wiki/xacro"
        name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->

--- a/pr2_description/robots/pr2_no_kinect.urdf.xacro
+++ b/pr2_description/robots/pr2_no_kinect.urdf.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-       xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
+       xmlns:xacro="http://ros.org/wiki/xacro"
        name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->

--- a/pr2_description/robots/pr2_se.urdf.xacro
+++ b/pr2_description/robots/pr2_se.urdf.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-       xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
+       xmlns:xacro="http://ros.org/wiki/xacro"
        name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->

--- a/pr2_description/urdf/base_v0/base.transmission.xacro
+++ b/pr2_description/urdf/base_v0/base.transmission.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!--  Caster wheel transmission   -->

--- a/pr2_description/urdf/base_v0/base.urdf.xacro
+++ b/pr2_description/urdf/base_v0/base.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/hokuyo_lx30_laser.urdf.xacro" />

--- a/pr2_description/urdf/forearm_v0/forearm.gazebo.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.gazebo.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_forearm_gazebo_v0" params="side">

--- a/pr2_description/urdf/forearm_v0/forearm.transmission.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.transmission.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_forearm_transmission_v0" params="side">

--- a/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
@@ -3,7 +3,7 @@
 <!-- XML namespaces -->
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include

--- a/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
        xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#slider"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_gripper_transmission_v0" params="side screw_reduction gear_ratio theta0 phi0 t0 L0 h a b r">

--- a/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
        xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#slider"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/gripper_v0/gripper.gazebo.xacro" />

--- a/pr2_description/urdf/head_v0/head.gazebo.xacro
+++ b/pr2_description/urdf/head_v0/head.gazebo.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_head_gazebo_v0" params="name">

--- a/pr2_description/urdf/head_v0/head.transmission.xacro
+++ b/pr2_description/urdf/head_v0/head.transmission.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
 

--- a/pr2_description/urdf/head_v0/head.urdf.xacro
+++ b/pr2_description/urdf/head_v0/head.urdf.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/head_v0/head.gazebo.xacro" />

--- a/pr2_description/urdf/sensors/double_stereo_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.gazebo.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Made by Kevin for double stereo camera for PR-2 Beta. -->

--- a/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/double_stereo_camera.gazebo.xacro" />

--- a/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <property name="M_PI" value="3.1415926535897931" />

--- a/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- This urdf macro defines following sensors:

--- a/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
+++ b/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/hokuyo_lx30_laser.gazebo.xacro" />

--- a/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+      xmlns:interface="http://ros.org/wiki/xacro"
       xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_camera.gazebo.xacro" />

--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <root xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+      xmlns:interface="http://ros.org/wiki/xacro"
       xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_prosilica_camera.gazebo.xacro" />

--- a/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
+++ b/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <root xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+      xmlns:interface="http://ros.org/wiki/xacro"
       xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/projector_wg6802418.gazebo.xacro" />

--- a/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <root xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+      xmlns:interface="http://ros.org/wiki/xacro"
       xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro" />

--- a/pr2_description/urdf/sensors/stereo_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/stereo_camera.gazebo.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- this macro is used for creating wide and narrow double stereo camera in simulation -->

--- a/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- stereo camera macro uses wge100_camera macros -->

--- a/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
@@ -2,7 +2,7 @@
 <!-- XML namespaces -->
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/wge100_camera.gazebo.xacro" />

--- a/pr2_description/urdf/shoulder_v0/shoulder.gazebo.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.gazebo.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_shoulder_gazebo_v0" params="side">

--- a/pr2_description/urdf/shoulder_v0/shoulder.transmission.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.transmission.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_shoulder_transmission_v0" params="side">

--- a/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
@@ -3,7 +3,7 @@
 <!-- XML namespaces -->
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="pr2_tilting_laser_gazebo_v0" params="name">
     <gazebo reference="${name}_mount_link">

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.transmission.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.transmission.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="pr2_tilting_laser_transmission_v0" params="name">
     <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_mount_trans">

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro" />

--- a/pr2_description/urdf/torso_v0/torso.transmission.xacro
+++ b/pr2_description/urdf/torso_v0/torso.transmission.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_torso_transmission_v0" params="name">

--- a/pr2_description/urdf/torso_v0/torso.urdf.xacro
+++ b/pr2_description/urdf/torso_v0/torso.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/torso_v0/torso.gazebo.xacro" />

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.gazebo.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.gazebo.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_upper_arm_gazebo_v0" params="side">

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.transmission.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.transmission.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- ============================   Upper Arm   ============================ -->

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
@@ -3,7 +3,7 @@
 <!-- XML namespaces -->
 <robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
+       xmlns:interface="http://ros.org/wiki/xacro"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include


### PR DESCRIPTION
When using in Kinetic xacro outputs the following warning:

```
inconsistent namespace redefinitions for xmlns:xacro:
 old: http://playerstage.sourceforge.net/gazebo/xmlschema/#interface
 new: http://ros.org/wiki/xacro (/home/dave/ros/current/ws_moveit/src/pr2_common/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro)
```

so i fixed that