### PR TITLE
pr2.urdf.xacro: support xacro:arg

### DIFF
--- a/pr2_description/robots/pr2.urdf.xacro
+++ b/pr2_description/robots/pr2.urdf.xacro
@@ -136,8 +136,10 @@
   </xacro:wge100_camera_v0>
 
   <!-- Kinect models -->
+  <xacro:arg name="KINECT1" default="false" />
+  <xacro:arg name="KINECT2" default="false" />
   <!-- Kinect2 xacro -->
-  <xacro:if value="$(optenv KINECT2 false)">
+  <xacro:if value="$(arg KINECT2)">
     <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect2.urdf.xacro" />
     <xacro:kinect2_v0 name="head_mount" parent="head_plate_frame" >
       <origin xyz="-0.137376 0 0.091746" rpy="0 0 0" />
@@ -145,8 +147,8 @@
   </xacro:if>
 
   <!-- Kinect1 xacro -->
-  <xacro:unless value="$(optenv KINECT2 false)">
-    <xacro:if value="$(optenv KINECT1 false)">
+  <xacro:unless value="$(arg KINECT2)">
+    <xacro:if value="$(arg KINECT1)">
       <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_prosilica_camera.urdf.xacro" />
       <!-- Base of Kinect/Prosilica Mount -->
       <xacro:kinect_prosilica_camera_swept_back_v0 name="head_mount" parent="head_plate_frame" >

--- a/pr2_description/robots/upload_pr2.launch
+++ b/pr2_description/robots/upload_pr2.launch
@@ -1,6 +1,8 @@
 <launch>
+  <arg name="KINECT1" default="$(optenv KINECT1 false)" />
+  <arg name="KINECT2" default="$(optenv KINECT2 false)" />
   <!-- send pr2 urdf to param server -->
   <group>
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2.urdf.xacro'" />
+    <param name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2.urdf.xacro' KINECT1:=$(arg KINECT1) KINECT2:=$(arg KINECT2)" />
   </group>
 </launch>


### PR DESCRIPTION
Currently, in order to spawn pr2 URDF as parameter in roslaunch, we must set environment variable `KINECT1=true` or `KINECT2=true` and this behavior is uncontrollable by roslaunch.
In this pull request, `xacro:arg` is used as variable `KINECT` instead of `optenv`, and set the default value as environment variables in `upload_pr2.launch`.
We can now control kinect both via roslaunch (e.g. `roslaunch pr2_description upload_pr2.launch KINECT1:=true`) and via env (e.g. `KINECT1=true roslaunch pr2_description upload_pr2.launch`)
