### PR TITLE
Fix pr2_description warnings

### DIFF
--- a/pr2_description/robots/pr2.urdf.xacro
+++ b/pr2_description/robots/pr2.urdf.xacro
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro"
-       name="pr2" >
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
 
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/robots/pr2_no_arms.urdf.xacro
+++ b/pr2_description/robots/pr2_no_arms.urdf.xacro
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro"
-       name="pr2" >
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/robots/pr2_no_kinect.urdf.xacro
+++ b/pr2_description/robots/pr2_no_kinect.urdf.xacro
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro"
-       name="pr2" >
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/robots/pr2_se.urdf.xacro
+++ b/pr2_description/robots/pr2_se.urdf.xacro
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro"
-       name="pr2" >
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/robots/upload_pr2.launch
+++ b/pr2_description/robots/upload_pr2.launch
@@ -3,6 +3,6 @@
   <arg name="KINECT2" default="$(optenv KINECT2 false)" />
   <!-- send pr2 urdf to param server -->
   <group>
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(find pr2_description)/robots/pr2.urdf.xacro' KINECT1:=$(arg KINECT1) KINECT2:=$(arg KINECT2)" />
+    <param name="robot_description" command="$(find xacro)/xacro '$(find pr2_description)/robots/pr2.urdf.xacro' --inorder KINECT1:=$(arg KINECT1) KINECT2:=$(arg KINECT2)" />
   </group>
 </launch>

--- a/pr2_description/test/test_urdf.cpp
+++ b/pr2_description/test/test_urdf.cpp
@@ -85,8 +85,7 @@ int walker( std::string & result, int& test_result)
         result += name;
         result += " ";
 
-        runExternalProcess("python `rospack find xacro`/xacro.py", name+" > `rospack find pr2_description`/test/tmp.urdf" );
-
+        runExternalProcess("rosrun xacro xacro", name+" --inorder > `rospack find pr2_description`/test/tmp.urdf" );
         std::string path = std::string(pwd)+"/test/tmp.urdf";
 
 

--- a/pr2_description/urdf/base_v0/base.transmission.xacro
+++ b/pr2_description/urdf/base_v0/base.transmission.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!--  Caster wheel transmission   -->
   <xacro:macro name="pr2_wheel_transmission_v0" params="suffix parent reflect">

--- a/pr2_description/urdf/base_v0/base.urdf.xacro
+++ b/pr2_description/urdf/base_v0/base.urdf.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/hokuyo_lx30_laser.urdf.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/base_v0/base.gazebo.xacro" />

--- a/pr2_description/urdf/common.xacro
+++ b/pr2_description/urdf/common.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:property name="M_PI" value="3.1415926535897931" />
   <xacro:property name="VELOCITY_LIMIT_SCALE" value="0.6" />

--- a/pr2_description/urdf/forearm_v0/forearm.gazebo.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.gazebo.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_forearm_gazebo_v0" params="side">
 

--- a/pr2_description/urdf/forearm_v0/forearm.transmission.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.transmission.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_forearm_transmission_v0" params="side">
 

--- a/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
@@ -1,10 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- XML namespaces -->
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include
        sensor and controller plugin specifications -->

--- a/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#slider"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_gripper_transmission_v0" params="side screw_reduction gear_ratio theta0 phi0 t0 L0 h a b r">
     <!-- [lr]_gripper_joint is a fictitious joint, used by transmission for controller gap   -->

--- a/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:joint="http://playerstage.sourceforge.net/gazebo/xmlschema/#slider"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/gripper_v0/gripper.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/gripper_v0/gripper.transmission.xacro" />

--- a/pr2_description/urdf/head_v0/head.gazebo.xacro
+++ b/pr2_description/urdf/head_v0/head.gazebo.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_head_gazebo_v0" params="name">
     <gazebo reference="${name}_plate_frame">

--- a/pr2_description/urdf/head_v0/head.transmission.xacro
+++ b/pr2_description/urdf/head_v0/head.transmission.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
 
   <xacro:macro name="pr2_head_pan_transmission_v0" params="name">

--- a/pr2_description/urdf/head_v0/head.urdf.xacro
+++ b/pr2_description/urdf/head_v0/head.urdf.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/head_v0/head.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/head_v0/head.transmission.xacro" />

--- a/pr2_description/urdf/sensors/double_stereo_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.gazebo.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Made by Kevin for double stereo camera for PR-2 Beta. -->
   <!-- Needs calibration verification, and CAD check. -->

--- a/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/double_stereo_camera.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/sensors/stereo_camera.urdf.xacro" />

--- a/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:property name="M_PI" value="3.1415926535897931" />
 

--- a/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- This urdf macro defines following sensors:
        prosilica

--- a/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
+++ b/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/hokuyo_lx30_laser.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-      xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://ros.org/wiki/xacro"
-      xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-      xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://ros.org/wiki/xacro"
-      xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_prosilica_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
+++ b/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-      xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://ros.org/wiki/xacro"
-      xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/projector_wg6802418.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-      xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-      xmlns:interface="http://ros.org/wiki/xacro"
-      xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/stereo_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/stereo_camera.gazebo.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- this macro is used for creating wide and narrow double stereo camera in simulation -->
   <xacro:macro name="stereo_camera_gazebo_v0" params="name focal_length hfov image_width image_height">

--- a/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- stereo camera macro uses wge100_camera macros -->
   <xacro:include filename="$(find pr2_description)/urdf/sensors/wge100_camera.urdf.xacro" />

--- a/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <!-- XML namespaces -->
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/wge100_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/shoulder_v0/shoulder.gazebo.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.gazebo.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_shoulder_gazebo_v0" params="side">
 

--- a/pr2_description/urdf/shoulder_v0/shoulder.transmission.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.transmission.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_shoulder_transmission_v0" params="side">
 

--- a/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
@@ -1,10 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- XML namespaces -->
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include
        sensor and controller plugin specifications -->

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="pr2_tilting_laser_gazebo_v0" params="name">
     <gazebo reference="${name}_mount_link">
     </gazebo>

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.transmission.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.transmission.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="pr2_tilting_laser_transmission_v0" params="name">
     <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_mount_trans">
       <actuator name="${name}_mount_motor" />

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/tilting_laser_v0/tilting_laser.transmission.xacro" />

--- a/pr2_description/urdf/torso_v0/torso.transmission.xacro
+++ b/pr2_description/urdf/torso_v0/torso.transmission.xacro
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_torso_transmission_v0" params="name">
 

--- a/pr2_description/urdf/torso_v0/torso.urdf.xacro
+++ b/pr2_description/urdf/torso_v0/torso.urdf.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/torso_v0/torso.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/torso_v0/torso.transmission.xacro" />

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.gazebo.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.gazebo.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_upper_arm_gazebo_v0" params="side">
     <gazebo reference="${side}_upper_arm_link">

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.transmission.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.transmission.xacro
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- ============================   Upper Arm   ============================ -->
 

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
@@ -1,10 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- XML namespaces -->
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
-       xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
-       xmlns:interface="http://ros.org/wiki/xacro"
-       xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include
        sensor and controller plugin specifications -->


### PR DESCRIPTION
* removed all `playerstage` xml schema urdf warnings
* updated test to use `xacro` instead of the deprecated `xacro.py` and to use `--inorder`