### PR TITLE
xmlns should include www

### DIFF
--- a/pr2_description/gazebo/gazebo.urdf.xacro
+++ b/pr2_description/gazebo/gazebo.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <gazebo>
     <plugin name="gazebo_ros_controller_manager" filename="libgazebo_ros_controller_manager.so">

--- a/pr2_description/robots/pr2.urdf.xacro
+++ b/pr2_description/robots/pr2.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="pr2" >
 
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/robots/pr2_no_arms.urdf.xacro
+++ b/pr2_description/robots/pr2_no_arms.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/robots/pr2_no_kinect.urdf.xacro
+++ b/pr2_description/robots/pr2_no_kinect.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/robots/pr2_se.urdf.xacro
+++ b/pr2_description/robots/pr2_se.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="pr2" >
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="pr2" >
   
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- misc common stuff? -->

--- a/pr2_description/urdf/base_v0/base.gazebo.xacro
+++ b/pr2_description/urdf/base_v0/base.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_wheel_gazebo_v0" params="suffix parent">
     <gazebo reference="${parent}_${suffix}_wheel_link">

--- a/pr2_description/urdf/base_v0/base.transmission.xacro
+++ b/pr2_description/urdf/base_v0/base.transmission.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!--  Caster wheel transmission   -->
   <xacro:macro name="pr2_wheel_transmission_v0" params="suffix parent reflect">

--- a/pr2_description/urdf/base_v0/base.urdf.xacro
+++ b/pr2_description/urdf/base_v0/base.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/hokuyo_lx30_laser.urdf.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/base_v0/base.gazebo.xacro" />

--- a/pr2_description/urdf/common.xacro
+++ b/pr2_description/urdf/common.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:property name="M_PI" value="3.1415926535897931" />
   <xacro:property name="VELOCITY_LIMIT_SCALE" value="0.6" />

--- a/pr2_description/urdf/forearm_v0/forearm.gazebo.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_forearm_gazebo_v0" params="side">
 

--- a/pr2_description/urdf/forearm_v0/forearm.transmission.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.transmission.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_forearm_transmission_v0" params="side">
 

--- a/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
+++ b/pr2_description/urdf/forearm_v0/forearm.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- XML namespaces -->
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include
        sensor and controller plugin specifications -->

--- a/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:property name="finger_stop_kd"             value="1.0" />
   <xacro:property name="finger_stop_kp"             value="10000000.0" />

--- a/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_gripper_transmission_v0" params="side screw_reduction gear_ratio theta0 phi0 t0 L0 h a b r">
     <!-- [lr]_gripper_joint is a fictitious joint, used by transmission for controller gap   -->

--- a/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/gripper_v0/gripper.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/gripper_v0/gripper.transmission.xacro" />

--- a/pr2_description/urdf/head_v0/head.gazebo.xacro
+++ b/pr2_description/urdf/head_v0/head.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_head_gazebo_v0" params="name">
     <gazebo reference="${name}_plate_frame">

--- a/pr2_description/urdf/head_v0/head.transmission.xacro
+++ b/pr2_description/urdf/head_v0/head.transmission.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 
   <xacro:macro name="pr2_head_pan_transmission_v0" params="name">

--- a/pr2_description/urdf/head_v0/head.urdf.xacro
+++ b/pr2_description/urdf/head_v0/head.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/head_v0/head.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/head_v0/head.transmission.xacro" />

--- a/pr2_description/urdf/sensors/double_stereo_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Made by Kevin for double stereo camera for PR-2 Beta. -->
   <!-- Needs calibration verification, and CAD check. -->

--- a/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/double_stereo_camera.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/sensors/stereo_camera.urdf.xacro" />

--- a/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:property name="M_PI" value="3.1415926535897931" />
 

--- a/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- This urdf macro defines following sensors:
        prosilica

--- a/pr2_description/urdf/sensors/hokuyo_lx30_laser.gazebo.xacro
+++ b/pr2_description/urdf/sensors/hokuyo_lx30_laser.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="hokuyo_lx30_laser_gazebo_v0" params="name ros_topic update_rate min_angle max_angle">
     <gazebo reference="${name}_link">

--- a/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
+++ b/pr2_description/urdf/sensors/hokuyo_lx30_laser.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/hokuyo_lx30_laser.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/kinect2.gazebo.xacro
+++ b/pr2_description/urdf/sensors/kinect2.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 <xacro:macro name="kinect2_ir_gazebo_v0" params="link_name frame_name camera_name">
   <gazebo reference="${link_name}">

--- a/pr2_description/urdf/sensors/kinect2.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect2.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect2.gazebo.xacro" />
 
   <xacro:property name="ir_depth_rgb_offset_y" value="0.01"/> <!-- FIXME: what is this offset? -->

--- a/pr2_description/urdf/sensors/kinect_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/kinect_camera.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   
 <xacro:macro name="kinect_camera_gazebo_v0" params="name">
   <gazebo reference="${name}_frame">

--- a/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_camera.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 <xacro:macro name="kinect_ir_gazebo_v0" params="link_name frame_name camera_name">
   <gazebo reference="${link_name}">

--- a/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect_prosilica_camera.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/kinect_prosilica_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro
+++ b/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="microstrain_3dmgx2_imu_gazebo_v0" params="name imu_topic update_rate stdev">
     <gazebo>

--- a/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.urdf.xacro
+++ b/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/projector_wg6802418.gazebo.xacro
+++ b/pr2_description/urdf/sensors/projector_wg6802418.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://www.ros.org/wiki/xacro">
   
 <!-- this controller is pushed into a body scope (previously model scope)
      this will only work with added r36415 patch in simulator_gazebo stack

--- a/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
+++ b/pr2_description/urdf/sensors/projector_wg6802418.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/projector_wg6802418.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://www.ros.org/wiki/xacro">
   
 <xacro:macro name="prosilica_cam_gazebo_v0" params="camera_name frame_name">
   <gazebo reference="${frame_name}_frame">

--- a/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/prosilica_gc2450_camera.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<root xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/prosilica_gc2450_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/sensors/stereo_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/stereo_camera.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- this macro is used for creating wide and narrow double stereo camera in simulation -->
   <xacro:macro name="stereo_camera_gazebo_v0" params="name focal_length hfov image_width image_height">

--- a/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/stereo_camera.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- stereo camera macro uses wge100_camera macros -->
   <xacro:include filename="$(find pr2_description)/urdf/sensors/wge100_camera.urdf.xacro" />

--- a/pr2_description/urdf/sensors/wge100_camera.gazebo.xacro
+++ b/pr2_description/urdf/sensors/wge100_camera.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="wge100_camera_gazebo_v0" params="name camera_name image_format image_topic_name camera_info_topic_name hfov focal_length frame_id hack_baseline image_width image_height">
     <gazebo reference="${name}_frame">
       <sensor type="camera" name="${name}_sensor">

--- a/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/wge100_camera.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- XML namespaces -->
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <xacro:include filename="$(find pr2_description)/urdf/sensors/wge100_camera.gazebo.xacro" />
 

--- a/pr2_description/urdf/shoulder_v0/shoulder.gazebo.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_shoulder_gazebo_v0" params="side">
 

--- a/pr2_description/urdf/shoulder_v0/shoulder.transmission.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.transmission.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_shoulder_transmission_v0" params="side">
 

--- a/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
+++ b/pr2_description/urdf/shoulder_v0/shoulder.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- XML namespaces -->
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include
        sensor and controller plugin specifications -->

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="pr2_tilting_laser_gazebo_v0" params="name">
     <gazebo reference="${name}_mount_link">
     </gazebo>

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.transmission.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.transmission.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="pr2_tilting_laser_transmission_v0" params="name">
     <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_mount_trans">
       <actuator name="${name}_mount_motor" />

--- a/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
+++ b/pr2_description/urdf/tilting_laser_v0/tilting_laser.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/tilting_laser_v0/tilting_laser.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/tilting_laser_v0/tilting_laser.transmission.xacro" />

--- a/pr2_description/urdf/torso_v0/torso.gazebo.xacro
+++ b/pr2_description/urdf/torso_v0/torso.gazebo.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_torso_gazebo_v0" params="name">
 

--- a/pr2_description/urdf/torso_v0/torso.transmission.xacro
+++ b/pr2_description/urdf/torso_v0/torso.transmission.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_torso_transmission_v0" params="name">
 

--- a/pr2_description/urdf/torso_v0/torso.urdf.xacro
+++ b/pr2_description/urdf/torso_v0/torso.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find pr2_description)/urdf/torso_v0/torso.gazebo.xacro" />
   <xacro:include filename="$(find pr2_description)/urdf/torso_v0/torso.transmission.xacro" />

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.gazebo.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="pr2_upper_arm_gazebo_v0" params="side">
     <gazebo reference="${side}_upper_arm_link">

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.transmission.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.transmission.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- ============================   Upper Arm   ============================ -->
 

--- a/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
+++ b/pr2_description/urdf/upper_arm_v0/upper_arm.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- XML namespaces -->
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Things that are needed only for Gazebo (not the physical robot).  These include
        sensor and controller plugin specifications -->


### PR DESCRIPTION
According to the tutorials:
http://wiki.ros.org/urdf/Tutorials/Using%20Xacro%20to%20Clean%20Up%20a%20URDF%20File

xacro complains when some xacro components specify the URL
as http://www.ros.org/wiki/xacro and others
as http://ros.org/wiki/xacro.

This is a small follow-up to #269.