### PR TITLE
Revert #255

### DIFF
--- a/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
+++ b/pr2_description/urdf/gripper_v0/gripper.transmission.xacro
@@ -38,7 +38,7 @@
       <!-- screw joint to capture gripper "dynamics" -->
       <simulated_actuated_joint name="${side}_gripper_motor_screw_joint"
                                 passive_actuated_joint="${side}_gripper_motor_slider_joint"
-                                simulated_reduction="314.16"   />
+                                simulated_reduction="3141.6"   />
     </transmission>
   </xacro:macro>
 


### PR DESCRIPTION
related to https://github.com/PR2/pr2_common/issues/245 and https://github.com/PR2/pr2_common/pull/255

In #245 and #255, they try to work PR2 on Gazebo in Indigo version and make this change.
However, this modification doesn't make sense, and it doesn't work on Kinetic and Melodic, which uses higher version Gazebo.
I revert the PR and I checked it's working on Kinetic Gazebo.