### PR TITLE
Update travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-pr2_common [![Build Status](https://travis-ci.com/PR2/pr2_common.svg?branch=kinetic-devel)](https://travis-ci.com/PR2/pr2_common)
+pr2_common [![Build Status](https://travis-ci.com/PR2/pr2_common.svg?branch=melodic-devel)](https://travis-ci.com/PR2/pr2_common)
 =================================================================================================================================

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-pr2_common [![Build Status](https://travis-ci.org/pr2/pr2_common.svg?branch=kinetic-devel)](https://travis-ci.org/pr2/pr2_common)
+pr2_common [![Build Status](https://travis-ci.com/PR2/pr2_common.svg?branch=kinetic-devel)](https://travis-ci.com/PR2/pr2_common)
 =================================================================================================================================


### PR DESCRIPTION
Use travis-ci.com instead of travis-ci.org