### PR TITLE
Cleanup collision/auxiliary shapes in urdf

### DIFF
--- a/pr2_description/urdf/base_v0/base.urdf.xacro
+++ b/pr2_description/urdf/base_v0/base.urdf.xacro
@@ -172,12 +172,6 @@
     <!-- base_footprint is a fictitious link(frame) that is on the ground right below base_link origin,
          navigation stack dedpends on this frame -->
     <link name="${name}_footprint">
-      <inertial>
-        <mass value="1.0" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.01" ixy="0.0" ixz="0.0"
-                 iyy="0.01" iyz="0.0" izz="0.01" />
-      </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>

--- a/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
+++ b/pr2_description/urdf/sensors/double_stereo_camera.urdf.xacro
@@ -29,16 +29,6 @@
         <inertia ixx="0.001" ixy="0.0" ixz="0.0"
                  iyy="0.001" iyz="0.0" izz="0.01" />
       </inertial>
-
-      <!-- Should probably get real visuals here at some point -->
-      <visual>
-        <origin xyz="${stereo_center_box_center_offset_x} 0 ${stereo_center_box_center_offset_z}" rpy="0 0 0" />
-        <geometry>
-          <box size="${stereo_size_x} ${stereo_size_y} ${stereo_size_z}" />
-        </geometry>
-        <material name="Blue" />
-      </visual>
-
     </link>
 
     <!-- Wide camera is on robot right (hca1), narrow on left (hca2)? -->

--- a/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
+++ b/pr2_description/urdf/sensors/head_sensor_package.urdf.xacro
@@ -28,17 +28,6 @@
         <inertia ixx="0.001" ixy="0.0" ixz="0.0"
                  iyy="0.001" iyz="0.0" izz="0.01" />
       </inertial>
-
-      <!-- Should probably get real visuals here at some point -->
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.01 0.01 0.01" />
-        </geometry>
-        
-        <material name="Blue" />
-      </visual>
-
     </link>
 
     <!-- Prosilica Camera -->

--- a/pr2_description/urdf/sensors/kinect2.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect2.urdf.xacro
@@ -29,9 +29,9 @@
         </material>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin xyz="-0.042 0 0.1" rpy="0 0 0"/>
         <geometry>
-          <sphere radius="0.0005"/>
+          <box size="0.12 0.3 0.2"/>
         </geometry>
       </collision>
     </link>

--- a/pr2_description/urdf/sensors/kinect2.urdf.xacro
+++ b/pr2_description/urdf/sensors/kinect2.urdf.xacro
@@ -50,18 +50,6 @@
                  iyy="0.01"  iyz="0.0"
                  izz="0.01" />
       </inertial>
-      <visual>
-        <origin xyz="0.0 0.0 0" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="0.0005"/>
-        </geometry>
-      </visual>
-      <collision>
-        <origin xyz="0.0 0.0 0" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="0.0005"/>
-        </geometry>
-      </collision>
     </link>
     <!-- kinect2 ir sensor frame -->
     <joint name="${name}_kinect2_ir_optical_frame_joint" type="fixed">
@@ -90,19 +78,6 @@
                  iyy="0.01"  iyz="0.0"
                  izz="0.01" />
       </inertial>
-      <visual>
-        <origin xyz="${cal_kinect_x}            ${cal_kinect_y}                 ${cal_kinect_z}"
-                rpy="${-M_PI/2+cal_kinect_roll} ${0.0+cal_kinect_pitch}         ${-M_PI/2+cal_kinect_yaw}" />
-        <geometry>
-          <sphere radius="0.0005"/>
-        </geometry>
-      </visual>
-      <collision>
-        <origin xyz="0.0 0.0 0" rpy="0 0 0"/>
-        <geometry>
-          <sphere radius="0.0005"/>
-        </geometry>
-      </collision>
     </link>
 
     <!-- kinect2 rgb sensor frame -->


### PR DESCRIPTION
[MoveIt recently changed its policy concerning empty collision geometries](https://github.com/ros-planning/moveit/pull/1952).
With these changes, the system will warn about visual geometry without associated collision geometries:

> ros.moveit_core.robot_model.empty_collision_geometry: Link sensor_mount_link has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
> ros.moveit_core.robot_model.empty_collision_geometry: Link double_stereo_link has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.

This pull-request cleans up the PR2 descriptions and removes all useless auxiliary shapes to get rid of these warnings.

Additionally, KDL complains for a long time that the robot's root link must not contain an inertial specification. As the inertial values here are fictitious, I remove them too.

Lastly, the collision geometry of the kinect2 camera did not exist at all (it was practically disabled by a 5mm sphere). I added a bounding box instead, as arm motions with an attached object can indeed reach the spoiler.
Here's the before/after pictures for the last change:

![pr2_head_mount_kinect2](https://user-images.githubusercontent.com/680358/76779586-e35fdb00-67ab-11ea-89d6-2b485839a28f.png)
![pr2_kinect2_adjusted](https://user-images.githubusercontent.com/680358/76779846-4cdfe980-67ac-11ea-98a0-d7d3e6c6bd45.png)

@k-okada please review