### PR TITLE
Remove inertial tag from fictitious base_footprint link

### DIFF
--- a/pr2_description/urdf/base_v0/base.urdf.xacro
+++ b/pr2_description/urdf/base_v0/base.urdf.xacro
@@ -172,12 +172,6 @@
     <!-- base_footprint is a fictitious link(frame) that is on the ground right below base_link origin,
          navigation stack dedpends on this frame -->
     <link name="${name}_footprint">
-      <inertial>
-        <mass value="1.0" />
-        <origin xyz="0 0 0" />
-        <inertia ixx="0.01" ixy="0.0" ixz="0.0"
-                 iyy="0.01" iyz="0.0" izz="0.01" />
-      </inertial>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>


### PR DESCRIPTION
Does anything require a non-zero inertial tag for all links? I'm a beginner to the ROS ecosystem so I'm not sure, but the presence of this tag is giving a warning when I ran the MoveIt! demo for the PR2: 
`roslaunch pr2_moveit_config demo.launch`
Specifically the warning (which gets repeated a few times) is:
`[ WARN] [1588898022.595792839]: The root link base_footprint has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.`

I figured that since `base_footprint` is already fictitious you could just remove the inertial tag from it as well, with mass/inertial values defaulting to 0.