### PR TITLE
fix typo pr2_etherCAT -> pr2_ethercat

### DIFF
--- a/pr2_dashboard_aggregator/dashboard_aggregator.py
+++ b/pr2_dashboard_aggregator/dashboard_aggregator.py
@@ -55,7 +55,7 @@ class DashboardAggregator:
     rospy.Subscriber("ddwrt/accesspoint", AccessPoint, self.accessPointCB)
     self.last_access_point = 0
     # Motor State
-    rospy.Subscriber("pr2_etherCAT/motors_halted", Bool, self.motorsHaltedCB)
+    rospy.Subscriber("pr2_ethercat/motors_halted", Bool, self.motorsHaltedCB)
     self.last_motors_halted = 0
 
   def motorsHaltedCB(self, msg):


### PR DESCRIPTION
`pr2_etherCAT` -> `pr2_ethercat`

`pr2_ethercat` node name is changed in this commit.
https://github.com/PR2/pr2_robot/commit/f7f0960ec413a61ec65ed81544214f223b3057d2