### PR TITLE
pr2_description/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro

### DIFF
--- a/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro
+++ b/pr2_description/urdf/sensors/microstrain_3dmgx2_imu.gazebo.xacro
@@ -11,7 +11,7 @@
         <topicName>${imu_topic}</topicName>
         <gaussianNoise>${stdev*stdev}</gaussianNoise>
         <xyzOffset>0 0 0</xyzOffset> 
-        <rpyOffset>0 -180.0 0</rpyOffset>
+        <rpyOffset>0 ${-180.0*M_PI/180.0} 0</rpyOffset>
         <serviceName>/default_imu</serviceName>
       </plugin>
     </gazebo>


### PR DESCRIPTION
IMU orienattion is different between noetic vs melodic, may be because of sdformat9 vs sdformat11 ??? (https://github.com/gazebosim/sdformat/pull/497)

This PR changed `<rpyOffset>` from degree to radius,

noetic
![Screenshot from 2022-10-24 18-31-58](https://user-images.githubusercontent.com/493276/197537016-76951b3f-8e50-4d49-a197-54b727f3d0fc.png)

melodic
![Screenshot from 2022-10-24 18-33-16](https://user-images.githubusercontent.com/493276/197537051-c096d6bb-d61a-4320-95b6-369587ee558a.png)

